### PR TITLE
start writing a RLN node: add chain monitor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,12 +91,22 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clightningrpc"
-version = "0.2.0"
+version = "0.3.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ae583d1efb5a0cb21d77ef53f872f104c872b5e05cc150b277d15afe13e974"
+checksum = "33118cf6fc0a00cffebefb718ab1bffe9eb03dbe5e4026a7a6c6dd4d390d08ea"
+dependencies = [
+ "clightningrpc-common",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "clightningrpc-common"
+version = "0.3.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d9821ddb8b5eee8f922fea6871f8684cf3eb74a1cb54f6a6782df70fe28b37"
 dependencies = [
  "serde",
- "serde_derive",
  "serde_json",
 ]
 
@@ -142,9 +152,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
+name = "lightning"
+version = "0.0.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "087add70f81d2fdc6d4409bc0cef69e11ad366ef1d0068550159bd22b3ac8664"
+dependencies = [
+ "bitcoin",
+]
+
+[[package]]
+name = "lightning-persister"
+version = "0.0.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48b28023f8b84764e0b861389fc865a1a1dc3896616a14678ece389b0811fe04"
+dependencies = [
+ "bitcoin",
+ "libc",
+ "lightning",
+ "winapi",
+]
+
+[[package]]
+name = "ln_node"
+version = "0.1.0"
+dependencies = [
+ "bitcoin_basics",
+ "bitcoincore-rpc",
+ "lightning",
+ "lightning-persister",
+ "time",
+]
+
+[[package]]
 name = "ln_workshop"
 version = "0.0.0"
 dependencies = [
+ "bitcoin_basics",
  "bitcoincore-rpc",
  "clightningrpc",
  "secp256k1",
@@ -178,6 +221,15 @@ dependencies = [
  "miniscript",
  "secp256k1",
  "trybuild",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -245,6 +297,7 @@ name = "rust-bitcoin-workshop"
 version = "0.0.0"
 dependencies = [
  "bitcoin_basics",
+ "ln_node",
  "ln_workshop",
  "miniscript_workshop",
 ]
@@ -325,6 +378,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "time"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c"
+dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ path = "main.rs"
 bitcoin_basics = { path = "basics"}
 miniscript_workshop = { path = "miniscript_workshop"}
 ln_workshop = { path = "ln"}
-
+ln_node = { path = "rln-node"}

--- a/rln-node/Cargo.toml
+++ b/rln-node/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "ln_node"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+name = "rlnnode"
+path = "src/lib.rs"
+
+[dependencies]
+lightning = "0.0.113"
+time = {version = "0.3", features = ["formatting"]}
+bitcoincore-rpc = {version = "0.16.0"}
+lightning-persister = {version = "0.0.113"}
+
+bitcoin_basics = { path = "../basics" }

--- a/rln-node/src/bitcoin_client.rs
+++ b/rln-node/src/bitcoin_client.rs
@@ -1,0 +1,35 @@
+use bitcoincore_rpc::{Client, RpcApi};
+use bitcoin_basics::BitcoinClient;
+use lightning::chain::chaininterface::{BroadcasterInterface, FeeEstimator};
+
+pub struct BitcoindClient {
+    client: Client
+}
+
+impl BitcoindClient {
+    pub fn new() -> Self {
+        let client = Client::setup();
+        client.load_wallet_in_node("test_wallet");
+        client.get_dough_if_broke();
+        Self {
+            client
+        }
+    }
+}
+
+impl FeeEstimator for BitcoindClient {
+    fn get_est_sat_per_1000_weight(
+        &self,
+        _confirmation_target: lightning::chain::chaininterface::ConfirmationTarget,
+    ) -> u32 {
+        // TODO: more sophisticated
+        1000
+    }
+}
+
+impl BroadcasterInterface for BitcoindClient {
+    fn broadcast_transaction(&self, tx: &bitcoincore_rpc::bitcoin::Transaction) {
+        self.client.send_raw_transaction(tx).expect("Failed to send raw tx");
+    }
+}
+

--- a/rln-node/src/lib.rs
+++ b/rln-node/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod logger;
+pub mod bitcoin_client;

--- a/rln-node/src/logger.rs
+++ b/rln-node/src/logger.rs
@@ -1,0 +1,22 @@
+use lightning::util::logger::Logger;
+use time::OffsetDateTime;
+
+pub struct RLNLogger;
+
+impl Logger for RLNLogger {
+    fn log(&self, record: &lightning::util::logger::Record) {
+        let raw_log = record.args.to_string();
+
+        let log = format!(
+			"{} {:<5} [{}:{}] {}\n",
+			OffsetDateTime::now_utc().to_string(),
+			record.level.to_string(),
+			record.module_path,
+			record.line,
+			raw_log
+		);
+
+        println!("{}", log);
+    }
+}
+

--- a/rln-node/src/main.rs
+++ b/rln-node/src/main.rs
@@ -1,0 +1,21 @@
+use lightning::chain::chainmonitor::ChainMonitor;
+use lightning::chain::keysinterface::InMemorySigner;
+use lightning::chain::Filter;
+use lightning_persister::FilesystemPersister;
+use rlnnode::bitcoin_client::BitcoindClient;
+use rlnnode::logger::RLNLogger;
+
+fn main() {
+    let bitcoind_client = BitcoindClient::new();
+    let logger = RLNLogger;
+    let filter: Option<Box<dyn Filter>> = None;
+
+    let persister = FilesystemPersister::new("".to_owned());
+    let _chain_monitor: ChainMonitor<InMemorySigner, Box<_>, _, _, _, _> = ChainMonitor::new(
+        filter,
+        &bitcoind_client,
+        &logger,
+        &bitcoind_client,
+        &persister,
+    );
+}


### PR DESCRIPTION
Start working on an implementation for rust-lightining node for the workshop. The plan is to add the implementation in the workshop. The node can then be used to add two nodes and make payments over the LN network.