### PR TITLE
Initialize networking, add block sync, structures for pathfinding and invoice payments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "lightning-net-tokio"
+version = "0.0.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e94b019ffcbd423c67bc8e65093d46cf5c00ff696b4b633936fce6e4d0cb845"
+dependencies = [
+ "bitcoin",
+ "lightning",
+ "tokio",
+]
+
+[[package]]
 name = "lightning-persister"
 version = "0.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +260,7 @@ dependencies = [
  "bitcoincore-rpc",
  "lightning",
  "lightning-block-sync",
+ "lightning-net-tokio",
  "lightning-persister",
  "time",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "lightning-background-processor"
+version = "0.0.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2288d211a2ab15e2c9fb492fb99c7998df1a37f228552f703824ee678b8980c9"
+dependencies = [
+ "bitcoin",
+ "lightning",
+ "lightning-rapid-gossip-sync",
+]
+
+[[package]]
 name = "lightning-block-sync"
 version = "0.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,6 +238,19 @@ dependencies = [
  "bitcoin",
  "futures-util",
  "lightning",
+]
+
+[[package]]
+name = "lightning-invoice"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9680857590c3529cf8c7d32b04501f215f2bf1e029fdfa22f4112f66c1741e4"
+dependencies = [
+ "bech32",
+ "bitcoin_hashes",
+ "lightning",
+ "num-traits",
+ "secp256k1",
 ]
 
 [[package]]
@@ -253,13 +277,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "lightning-rapid-gossip-sync"
+version = "0.0.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488b68c7d24093d35a83f37c560e427f1085f4c5d37918b81b11d95cd3675a0f"
+dependencies = [
+ "bitcoin",
+ "lightning",
+]
+
+[[package]]
 name = "ln_node"
 version = "0.1.0"
 dependencies = [
  "bitcoin_basics",
  "bitcoincore-rpc",
  "lightning",
+ "lightning-background-processor",
  "lightning-block-sync",
+ "lightning-invoice",
  "lightning-net-tokio",
  "lightning-persister",
  "time",
@@ -322,6 +358,15 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/rln-node/Cargo.toml
+++ b/rln-node/Cargo.toml
@@ -16,6 +16,9 @@ bitcoincore-rpc = {version = "0.16.0"}
 lightning-persister = {version = "0.0.113"}
 lightning-block-sync = {version = "0.0.113"}
 lightning-net-tokio = { version = "0.0.113" }
+lightning-invoice = { version = "0.21" }
+lightning-background-processor = { version = "0.0.113" }
+
 
 tokio = { version = "1", features = [ "io-util", "macros", "rt", "rt-multi-thread", "sync", "net", "time" ] }
 

--- a/rln-node/Cargo.toml
+++ b/rln-node/Cargo.toml
@@ -15,6 +15,7 @@ time = {version = "0.3", features = ["formatting"]}
 bitcoincore-rpc = {version = "0.16.0"}
 lightning-persister = {version = "0.0.113"}
 lightning-block-sync = {version = "0.0.113"}
+lightning-net-tokio = { version = "0.0.113" }
 
 tokio = { version = "1", features = [ "io-util", "macros", "rt", "rt-multi-thread", "sync", "net", "time" ] }
 

--- a/rln-node/src/event_handler.rs
+++ b/rln-node/src/event_handler.rs
@@ -1,0 +1,5 @@
+use lightning::util::events::Event;
+
+pub fn handle_ldk_event(event: Event) {
+    println!("{:#?}", event);
+}

--- a/rln-node/src/lib.rs
+++ b/rln-node/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod logger;
 pub mod bitcoin_client;
 pub mod keys_manager;
+pub mod event_handler;

--- a/rln-node/src/logger.rs
+++ b/rln-node/src/logger.rs
@@ -1,6 +1,7 @@
 use lightning::util::logger::Logger;
 use time::OffsetDateTime;
 
+#[derive(Clone, Debug)]
 pub struct RLNLogger;
 
 impl Logger for RLNLogger {

--- a/rln-node/src/main.rs
+++ b/rln-node/src/main.rs
@@ -1,35 +1,65 @@
-use lightning::chain::chainmonitor::ChainMonitor;
-use lightning::chain::keysinterface::InMemorySigner;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use bitcoincore_rpc::bitcoin::blockdata::constants::genesis_block;
+use bitcoincore_rpc::bitcoin::secp256k1::rand::{thread_rng, RngCore};
+use bitcoincore_rpc::bitcoin::Network;
+use lightning::chain::chainmonitor;
+use lightning::chain::keysinterface::{InMemorySigner, KeysInterface, Recipient};
 use lightning::chain::{self, BestBlock, Filter};
-use lightning::ln::channelmanager::{ChainParameters, ChannelManager};
+use lightning::ln::channelmanager::{ChainParameters, SimpleArcChannelManager};
+use lightning::ln::peer_handler::{IgnoringMessageHandler, MessageHandler, SimpleArcPeerManager};
+use lightning::onion_message::OnionMessenger;
+use lightning::routing::gossip::{NetworkGraph, P2PGossipSync};
 use lightning::util::config::UserConfig;
 use lightning_block_sync::init::synchronize_listeners;
 use lightning_block_sync::UnboundedCache;
+use lightning_net_tokio::SocketDescriptor;
 use lightning_persister::FilesystemPersister;
 use rlnnode::bitcoin_client::BitcoindClient;
 use rlnnode::keys_manager::get_keys_manager;
 use rlnnode::logger::RLNLogger;
 
+type ChainMonitor = chainmonitor::ChainMonitor<
+    InMemorySigner,
+    Arc<dyn Filter + Send + Sync>,
+    Arc<BitcoindClient>,
+    Arc<BitcoindClient>,
+    Arc<RLNLogger>,
+    Arc<FilesystemPersister>,
+>;
+
+type ChannelManager =
+    SimpleArcChannelManager<ChainMonitor, BitcoindClient, BitcoindClient, RLNLogger>;
+
+type PeerManager = SimpleArcPeerManager<
+    SocketDescriptor,
+    ChainMonitor,
+    BitcoindClient,
+    BitcoindClient,
+    dyn chain::Access + Send + Sync,
+    RLNLogger,
+>;
+
 #[tokio::main]
 async fn main() {
     let ln_dir = "./node_1";
-    let bitcoind_client = BitcoindClient::new();
-    let logger = RLNLogger;
-    let filter: Option<Box<dyn Filter>> = None;
+    let bitcoind_client = Arc::new(BitcoindClient::new());
+    let logger = Arc::new(RLNLogger);
 
     // Use sample LDK chain persistor
-    let persister = FilesystemPersister::new("".to_owned());
-    let chain_monitor: ChainMonitor<InMemorySigner, Box<_>, _, _, _, _> = ChainMonitor::new(
-        filter,
-        &bitcoind_client,
-        &logger,
-        &bitcoind_client,
-        &persister,
-    );
+    let persister = Arc::new(FilesystemPersister::new("".to_owned()));
+    let chain_monitor: Arc<ChainMonitor> = Arc::new(chainmonitor::ChainMonitor::new(
+        None,
+        bitcoind_client.clone(),
+        logger.clone(),
+        bitcoind_client.clone(),
+        persister,
+    ));
 
     // Initialize key manager
-    let keys_manager = get_keys_manager(ln_dir);
-    let _channel_monitors = persister.read_channelmonitors(&keys_manager).unwrap();
+    let keys_manager = Arc::new(get_keys_manager(ln_dir));
+    // let _channel_monitors = persister.read_channelmonitors(&keys_manager).unwrap();
 
     // Create channel manager
     let (channel_manager_blockhash, channel_manager) = {
@@ -44,11 +74,11 @@ async fn main() {
         (
             best_blockhash,
             ChannelManager::new(
-                &bitcoind_client,
-                &chain_monitor,
-                &bitcoind_client,
-                &logger,
-                &keys_manager,
+                bitcoind_client.clone(),
+                chain_monitor.clone(),
+                bitcoind_client.clone(),
+                logger.clone(),
+                keys_manager.clone(),
                 UserConfig::default(),
                 chain_params,
             ),
@@ -63,12 +93,58 @@ async fn main() {
     )];
     let mut _chain_tip = Some(
         synchronize_listeners(
-            &bitcoind_client,
+            bitcoind_client,
             bitcoincore_rpc::bitcoin::Network::Regtest,
             &mut cache,
             chain_listeners,
         )
         .await
         .unwrap(),
+    );
+
+    // NetGraphMsgHandler
+    let genesis_hash = genesis_block(Network::Regtest).header.block_hash();
+    let network_graph = Arc::new(NetworkGraph::new(genesis_hash, logger.clone()));
+    let gossip_sync = Arc::new(P2PGossipSync::new(
+        Arc::clone(&network_graph),
+        None::<Arc<dyn chain::Access + Send + Sync>>,
+        logger.clone(),
+    ));
+
+    // Onion messenger
+    let channel_manager = Arc::new(channel_manager);
+    let onion_messenger = Arc::new(OnionMessenger::new(
+        keys_manager.clone(),
+        logger.clone(),
+        IgnoringMessageHandler {},
+    ));
+
+    // Peer manager
+    let mut epheremal_bytes = [0; 32];
+    thread_rng().fill_bytes(&mut epheremal_bytes);
+    let current_time = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let ln_message_handler = MessageHandler {
+        chan_handler: channel_manager.clone(),
+        route_handler: gossip_sync.clone(),
+        onion_message_handler: onion_messenger.clone(),
+    };
+
+    let _peer_manager: SimpleArcPeerManager<
+        SocketDescriptor,
+        ChainMonitor,
+        BitcoindClient,
+        BitcoindClient,
+        dyn chain::Access + Send + Sync,
+        RLNLogger,
+    > = PeerManager::new(
+        ln_message_handler,
+        keys_manager.get_node_secret(Recipient::Node).unwrap(),
+        current_time.try_into().unwrap(),
+        &epheremal_bytes,
+        logger.clone(),
+        IgnoringMessageHandler {},
     );
 }


### PR DESCRIPTION
This PR adds:
  - a simple peer manager 
  -  changes that modifies some of the types to make it easier to work with ChainManager, ChannelManager and PeerManager
  - lots of addition of Arcs and .clone()s to satisfy type system
  - networking for listening to peer connections
  - LDK chain listener for chain updates
  - dummy event listener that just prints event info
  - structure for path finding and invoice payments